### PR TITLE
chore/replace swift concurrency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "XSim",
-    platforms: [.macOS(.v10_15)],
+    platforms: [.macOS(.v12)],
     products: [
         .executable(name: "xsim", targets: ["XSim"]),
     ],

--- a/Sources/XSimCLI/Services/SimulatorService.swift
+++ b/Sources/XSimCLI/Services/SimulatorService.swift
@@ -69,20 +69,12 @@ final class SimulatorService: Sendable {
         do {
             try process.run()
 
-            // Drain both pipes using async read APIs
+            // Drain both pipes using async read APIs (macOS 12+ guaranteed)
             let stdoutTask = Task(priority: .userInitiated) { () -> Data in
-                if #available(macOS 12.0, *) {
-                    return await (try? outHandle.readToEnd()) ?? Data()
-                } else {
-                    return outHandle.readDataToEndOfFile()
-                }
+                await (try? outHandle.readToEnd()) ?? Data()
             }
             let stderrTask = Task(priority: .userInitiated) { () -> Data in
-                if #available(macOS 12.0, *) {
-                    return await (try? errHandle.readToEnd()) ?? Data()
-                } else {
-                    return errHandle.readDataToEndOfFile()
-                }
+                await (try? errHandle.readToEnd()) ?? Data()
             }
 
             // Await process exit or timeout


### PR DESCRIPTION
- **refactor(concurrency): adopt async/await for simctl execution with concurrent stdout/stderr draining and timeout race**
- **fix(concurrency): resolve Swift 6 compile errors by removing async-let capture in race and marking SimulatorService Sendable**
