### PR TITLE
feat(cli)!: align command names with simctl (start->boot, stop->shutdown)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 
 ## ビルド・テスト・実行
 - ビルド: `swift build` — 全ターゲットをビルド。
-- 実行: `swift run xsim list`（例: `swift run xsim start "iPhone 15"`）。
+- 実行: `swift run xsim list`（例: `swift run xsim boot "iPhone 15"`）。
 - テスト: `swift test` — XCTest を実行。Xcode と `xcrun simctl` が必要。
 - 整形: `make format` — SwiftFormat を実行。
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Xcode Simulator management tool – shortcuts for simctl commands
 
 Commands:
   list            List available simulators
-  start           Start a simulator
-  stop            Stop simulators
+  boot            Boot a simulator
+  shutdown        Shutdown simulators
   create          Create a new simulator
   delete          Delete a simulator
   doctor          Check environment and simctl support

--- a/Sources/XSimCLI/Commands/CreateCommand.swift
+++ b/Sources/XSimCLI/Commands/CreateCommand.swift
@@ -235,7 +235,7 @@ class CreateCommand: BaseSimCommand, Command {
 
         stdout <<< ""
         stdout <<< "Next steps:".dim
-        stdout <<< "  • Start the simulator: xsim start \"\(name)\"".dim
+        stdout <<< "  • Boot the simulator: xsim boot \"\(name)\"".dim
         stdout <<< "  • List all simulators: xsim list".dim
     }
 }

--- a/Sources/XSimCLI/Commands/DeleteCommand.swift
+++ b/Sources/XSimCLI/Commands/DeleteCommand.swift
@@ -7,7 +7,7 @@ class DeleteCommand: BaseSimCommand, Command {
     let shortDescription = "Delete a simulator"
     let longDescription = """
     Deletes the specified simulator device.
-    If the simulator is running, it will be stopped before deletion.
+    If the simulator is running, it will be shut down before deletion.
     This action cannot be undone.
 
     You can also delete all simulators for a given OS/runtime version using --runtime.
@@ -166,7 +166,7 @@ class DeleteCommand: BaseSimCommand, Command {
         if device.state.isRunning {
             stdout <<< "  Current state: \(DisplayFormat.coloredState(device.state))"
             stdout <<< ""
-            stdout <<< "Note: Running simulators will be stopped automatically".yellow
+            stdout <<< "Note: Running simulators will be shut down automatically".yellow
         }
 
         stdout <<< ""

--- a/Sources/XSimCLI/Commands/ListCommand.swift
+++ b/Sources/XSimCLI/Commands/ListCommand.swift
@@ -90,7 +90,7 @@ class ListCommand: BaseSimCommand, Command {
     private func displayNoDevicesMessage() {
         if showRunningOnly {
             stdout <<< "No simulators are running.".yellow
-            stdout <<< "To start a simulator: xsim start <device>".dim
+            stdout <<< "To boot a simulator: xsim boot <device>".dim
         } else if showAvailableOnly {
             stdout <<< "No available simulators.".yellow
             stdout <<< "To create a simulator: xsim create <name> <type> <runtime>".dim
@@ -260,7 +260,7 @@ class ListCommand: BaseSimCommand, Command {
 
         if runningCount == 0, !showRunningOnly {
             stdout <<< ""
-            stdout <<< "Tip: Use 'xsim start <device>' to boot a simulator".dim
+            stdout <<< "Tip: Use 'xsim boot <device>' to boot a simulator".dim
         }
     }
 

--- a/Sources/XSimCLI/Commands/StartCommand.swift
+++ b/Sources/XSimCLI/Commands/StartCommand.swift
@@ -1,18 +1,18 @@
 import Rainbow
 import SwiftCLI
 
-/// Command to start a simulator device
+/// Command to boot a simulator device
 class StartCommand: BaseSimCommand, Command {
-    let name = "start"
-    let shortDescription = "Start a simulator"
+    var name: String { "boot" }
+    var shortDescription: String { "Boot a simulator" }
     let longDescription = """
-    Starts the specified simulator device.
+    Boots the specified simulator device.
     You can specify the device by name or UUID.
 
     Examples:
-      xsim start "iPhone 16"                    # by name
-      xsim start 12345678-1234-1234-1234-123456789012  # by UUID
-      xsim start "iPhone 16" --runtime "iOS 26"   # disambiguate by runtime
+      xsim boot "iPhone 16"                    # by name
+      xsim boot 12345678-1234-1234-1234-123456789012  # by UUID
+      xsim boot "iPhone 16" --runtime "iOS 26"   # disambiguate by runtime
     """
 
     @Param var deviceIdentifier: String
@@ -24,7 +24,7 @@ class StartCommand: BaseSimCommand, Command {
 
     func execute() throws {
         do {
-            stdout <<< "Starting simulator...".dim
+            stdout <<< "Booting simulator...".dim
 
             // Start the simulator
             let simulatorService = try getService()
@@ -35,7 +35,7 @@ class StartCommand: BaseSimCommand, Command {
             if let device = findDevice(in: devices, identifier: deviceIdentifier) {
                 displayStartSuccess(device: device)
             } else {
-                stdout <<< "✓ Started simulator '\(deviceIdentifier)'".green
+                stdout <<< "✓ Booted simulator '\(deviceIdentifier)'".green
             }
 
         } catch let error as SimulatorError {
@@ -83,7 +83,7 @@ class StartCommand: BaseSimCommand, Command {
 
     /// Displays success message with device information
     private func displayStartSuccess(device: SimulatorDevice) {
-        stdout <<< "✓ Simulator started".green
+        stdout <<< "✓ Simulator booted".green
         stdout <<< ""
 
         let deviceTypeName = DisplayFormat.deviceTypeName(from: device.deviceTypeIdentifier)

--- a/Sources/XSimCLI/Commands/StopCommand.swift
+++ b/Sources/XSimCLI/Commands/StopCommand.swift
@@ -1,18 +1,18 @@
 import Rainbow
 import SwiftCLI
 
-/// Command to stop simulator devices
+/// Command to shut down simulator devices
 class StopCommand: BaseSimCommand, Command {
-    let name = "stop"
-    let shortDescription = "Stop simulators"
+    var name: String { "shutdown" }
+    var shortDescription: String { "Shutdown simulators" }
     let longDescription = """
-    Stops the specified simulator device.
-    If no device is specified, stops all running simulators.
+    Shuts down the specified simulator device.
+    If no device is specified, shuts down all running simulators.
 
     Examples:
-      xsim stop                                 # stop all running simulators
-      xsim stop "iPhone 15"                     # stop a specific device
-      xsim stop 12345678-1234-1234-1234-123456789012  # by UUID
+      xsim shutdown                             # shutdown all running simulators
+      xsim shutdown "iPhone 15"                 # shutdown a specific device
+      xsim shutdown 12345678-1234-1234-1234-123456789012  # by UUID
     """
 
     @Param var deviceIdentifier: String?
@@ -38,7 +38,7 @@ class StopCommand: BaseSimCommand, Command {
 
     /// Stops a specific device
     private func stopSpecificDevice(identifier: String) throws {
-        stdout <<< "Stopping simulator...".dim
+        stdout <<< "Shutting down simulator...".dim
 
         // Get device info before stopping
         let simulatorService = try getService()
@@ -65,7 +65,7 @@ class StopCommand: BaseSimCommand, Command {
             return
         }
 
-        stdout <<< "Stopping all running simulators...".dim
+        stdout <<< "Shutting down all running simulators...".dim
 
         // Stop all devices
         try simulatorService.stopSimulator(identifier: nil)
@@ -84,7 +84,7 @@ class StopCommand: BaseSimCommand, Command {
             throw CLI.Error(message: "")
 
         case let .deviceNotRunning(identifier):
-            stdout <<< "ℹ Device '\(identifier)' is already stopped".yellow
+            stdout <<< "ℹ Device '\(identifier)' is already shut down".yellow
 
             // Try to get device info to show current status
             do {
@@ -104,7 +104,7 @@ class StopCommand: BaseSimCommand, Command {
 
     /// Displays success message for stopping a specific device
     private func displayStopSuccess(device: SimulatorDevice) {
-        stdout <<< "✓ Stopped the simulator".green
+        stdout <<< "✓ Shut down the simulator".green
         stdout <<< ""
 
         let deviceTypeName = DisplayFormat.deviceTypeName(from: device.deviceTypeIdentifier)
@@ -119,7 +119,7 @@ class StopCommand: BaseSimCommand, Command {
 
     /// Displays success message for stopping all devices
     private func displayStopAllSuccess(stoppedDevices: [SimulatorDevice]) {
-        stdout <<< "✓ Stopped all simulators".green
+        stdout <<< "✓ Shut down all simulators".green
         stdout <<< ""
 
         stdout <<< "Stopped devices (\(stoppedDevices.count)):".bold
@@ -129,7 +129,7 @@ class StopCommand: BaseSimCommand, Command {
         }
 
         stdout <<< ""
-        stdout <<< "Tip: Use 'xsim start <device>' to boot a simulator again".dim
+        stdout <<< "Tip: Use 'xsim boot <device>' to boot a simulator again".dim
     }
 
     /// Displays current device status

--- a/Sources/XSimCLI/Models/SimulatorError.swift
+++ b/Sources/XSimCLI/Models/SimulatorError.swift
@@ -114,7 +114,7 @@ public enum SimulatorError: Error, LocalizedError, Equatable {
         case .deviceAlreadyRunning:
             "The device is already running; no action is needed"
         case .deviceNotRunning:
-            "Start the device with 'xsim start <device>'"
+            "Boot the device with 'xsim boot <device>'"
         case .invalidDeviceType:
             "Run 'xsim create --list-types' to list available device types"
         case .invalidRuntime:

--- a/Sources/XSimCLI/XSimCLI.swift
+++ b/Sources/XSimCLI/XSimCLI.swift
@@ -28,8 +28,8 @@ public class XSimCLI {
         // Register all available commands without heavy initialization
         cli.commands = [
             ListCommand(),
-            StartCommand(),
-            StopCommand(),
+            StartCommand(), // boot
+            StopCommand(), // shutdown
             CreateCommand(),
             DeleteCommand(),
             DoctorCommand(),


### PR DESCRIPTION
What/Why\n- Align CLI commands with simctl naming.\n- Users can now use `xsim boot` and `xsim shutdown` matching `simctl boot` / `simctl shutdown`.\n\nChanges\n- Rename commands: start -> boot, stop -> shutdown\n- Update help text, user-facing tips, and README examples\n- Remove legacy start/stop aliases per request\n\nBreaking Change\n- `xsim start` and `xsim stop` are removed. Please use `xsim boot` and `xsim shutdown`.\n\nManual Verification\n- Build and run locally: `swift build`, `swift run xsim help`\n- Try: `swift run xsim boot "iPhone 15"`, `swift run xsim shutdown`\


close #3 
