### PR TITLE
feat: show installed apps in xsim list

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ xsim list
 xsim list --truncate
 ```
 
+List installed apps:
+
+```sh
+# include non-default (user-installed) apps in the listing output
+xsim list --apps
+```
+
 
 Debug logging:
 

--- a/Sources/XSimCLI/Commands/ListCommand.swift
+++ b/Sources/XSimCLI/Commands/ListCommand.swift
@@ -13,6 +13,7 @@ class ListCommand: BaseSimCommand, Command {
       xsim list                    # show all devices
       xsim list --running          # only running devices
       xsim list --available        # only available devices
+      xsim list --apps             # include installed user apps per device
     """
 
     @Flag("-r", "--running", description: "Show only running simulators")
@@ -30,7 +31,15 @@ class ListCommand: BaseSimCommand, Command {
     @Flag("--truncate", description: "Truncate and align columns (legacy compact view)")
     var truncate: Bool
 
+    @Flag("--apps", description: "Include installed user apps for each simulator")
+    var includeInstalledApps: Bool
+
     override init() {}
+
+    private struct DeviceAppsInfo {
+        let apps: [SimulatorApp]
+        let errorMessage: String?
+    }
 
     func execute() throws {
         do {
@@ -62,7 +71,12 @@ class ListCommand: BaseSimCommand, Command {
                 return
             }
 
-            displayDevices(filteredDevices)
+            var appsInfo: [String: DeviceAppsInfo] = [:]
+            if includeInstalledApps {
+                appsInfo = gatherInstalledApps(for: filteredDevices, using: simulatorService)
+            }
+
+            displayDevices(filteredDevices, appsInfo: appsInfo)
 
         } catch let error as SimulatorError {
             throw CLI.Error(message: error.localizedDescription)
@@ -101,7 +115,7 @@ class ListCommand: BaseSimCommand, Command {
     }
 
     /// Displays devices in a formatted table
-    private func displayDevices(_ devices: [SimulatorDevice]) {
+    private func displayDevices(_ devices: [SimulatorDevice], appsInfo: [String: DeviceAppsInfo]) {
         // Group devices by runtime for better organization
         let groupedDevices = Dictionary(grouping: devices) { device in
             DisplayFormat.runtimeName(from: device.runtimeIdentifier)
@@ -125,7 +139,8 @@ class ListCommand: BaseSimCommand, Command {
             // Display devices for this runtime
             let sortedDevices = devicesForRuntime.sorted { $0.name < $1.name }
             for device in sortedDevices {
-                displayDeviceRow(device, nameWidth: nameW, stateWidth: stateW, typeWidth: typeW)
+                let info = appsInfo[device.udid]
+                displayDeviceRow(device, nameWidth: nameW, stateWidth: stateW, typeWidth: typeW, appsInfo: info)
             }
         }
 
@@ -203,7 +218,13 @@ class ListCommand: BaseSimCommand, Command {
     }
 
     /// Displays a single device row
-    private func displayDeviceRow(_ device: SimulatorDevice, nameWidth: Int, stateWidth: Int, typeWidth: Int) {
+    private func displayDeviceRow(
+        _ device: SimulatorDevice,
+        nameWidth: Int,
+        stateWidth: Int,
+        typeWidth: Int,
+        appsInfo: DeviceAppsInfo?
+    ) {
         let resolvedTypeName = DisplayFormat.deviceTypeName(from: device.deviceTypeIdentifier)
 
         if truncate {
@@ -224,6 +245,28 @@ class ListCommand: BaseSimCommand, Command {
             let typeCol = DisplayFormat.pad(resolvedTypeName, to: typeWidth)
 
             stdout <<< "\(nameCol) \(stateCol) \(typeCol) \(device.udid.dim)"
+        }
+
+        guard let appsInfo else { return }
+
+        let indent = "    "
+        if let error = appsInfo.errorMessage, !error.isEmpty {
+            stdout <<< "\(indent)⚠️  Failed to load apps: \(error)".yellow
+            return
+        }
+
+        if appsInfo.apps.isEmpty {
+            stdout <<< "\(indent)(No user apps installed)".dim
+            return
+        }
+
+        for app in appsInfo.apps {
+            var line = "\(indent)- \(app.displayName)"
+            if let version = app.version {
+                line += " (\(version))"
+            }
+            line += " — \(app.bundleIdentifier)"
+            stdout <<< line.dim
         }
     }
 
@@ -262,6 +305,23 @@ class ListCommand: BaseSimCommand, Command {
             stdout <<< ""
             stdout <<< "Tip: Use 'xsim boot <device>' to boot a simulator".dim
         }
+    }
+
+    private func gatherInstalledApps(for devices: [SimulatorDevice], using service: SimulatorService) -> [String: DeviceAppsInfo] {
+        var result: [String: DeviceAppsInfo] = [:]
+
+        for device in devices {
+            do {
+                let apps = try service.listInstalledUserApps(for: device)
+                result[device.udid] = DeviceAppsInfo(apps: apps, errorMessage: nil)
+            } catch let error as SimulatorError {
+                result[device.udid] = DeviceAppsInfo(apps: [], errorMessage: error.localizedDescription)
+            } catch {
+                result[device.udid] = DeviceAppsInfo(apps: [], errorMessage: error.localizedDescription)
+            }
+        }
+
+        return result
     }
 
     // Identifier and column helpers moved to DisplayFormat

--- a/Sources/XSimCLI/Models/SimulatorApp.swift
+++ b/Sources/XSimCLI/Models/SimulatorApp.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Represents an application installed inside a simulator device
+public struct SimulatorApp: Equatable {
+    public enum ApplicationType: String {
+        case user = "User"
+        case system = "System"
+        case unknown
+
+        init(rawValue: String?) {
+            guard let rawValue else {
+                self = .unknown
+                return
+            }
+            self = ApplicationType(rawValue: rawValue) ?? .unknown
+        }
+
+        /// Returns true when the app is considered a user-installed application.
+        public var isUserApp: Bool {
+            switch self {
+            case .user:
+                true
+            case .system, .unknown:
+                false
+            }
+        }
+    }
+
+    /// Bundle identifier for the application
+    public let bundleIdentifier: String
+
+    /// Display name resolved from the bundle (if available)
+    public let name: String?
+
+    /// Version string, derived from either CFBundleShortVersionString or CFBundleVersion
+    public let version: String?
+
+    /// Application type reported by simctl (System/User)
+    public let applicationType: ApplicationType
+
+    public init(bundleIdentifier: String, name: String?, version: String?, applicationType: ApplicationType) {
+        self.bundleIdentifier = bundleIdentifier
+        self.name = name
+        self.version = version
+        self.applicationType = applicationType
+    }
+
+    /// Convenience accessor prioritising the display name when available.
+    public var displayName: String { name ?? bundleIdentifier }
+}

--- a/Sources/XSimCLI/Services/SimulatorService.swift
+++ b/Sources/XSimCLI/Services/SimulatorService.swift
@@ -280,6 +280,49 @@ class SimulatorService {
         return devices
     }
 
+    /// Returns the list of user-installed applications for a given simulator.
+    /// - Parameter device: Simulator device whose apps should be inspected.
+    /// - Returns: Array of SimulatorApp filtered to exclude default/system apps.
+    func listInstalledUserApps(for device: SimulatorDevice) throws -> [SimulatorApp] {
+        return try listInstalledApps(forUDID: device.udid, includeSystemApps: false)
+    }
+
+    /// Returns the list of installed applications for a simulator UUID.
+    /// - Parameters:
+    ///   - udid: Simulator identifier
+    ///   - includeSystemApps: Include system apps when true (defaults to true for internal callers)
+    private func listInstalledApps(forUDID udid: String, includeSystemApps: Bool) throws -> [SimulatorApp] {
+        let data = try executeSimctlCommand(arguments: ["listapps", udid], requiresJSON: true, timeoutSeconds: 15)
+        let response = try parseJSONOutput(data, as: [String: SimctlAppData].self)
+
+        var apps: [SimulatorApp] = []
+
+        for (bundleID, appData) in response {
+            let resolvedBundleID = appData.bundleIdentifier.trimmedNonEmpty ?? bundleID
+            guard !resolvedBundleID.isEmpty else { continue }
+
+            let type = SimulatorApp.ApplicationType(rawValue: appData.applicationType)
+            if !includeSystemApps, !type.isUserApp {
+                continue
+            }
+
+            let displayName = appData.displayName.trimmedNonEmpty ?? appData.bundleName.trimmedNonEmpty
+            let version = appData.shortVersion.trimmedNonEmpty ?? appData.version.trimmedNonEmpty
+
+            let app = SimulatorApp(
+                bundleIdentifier: resolvedBundleID,
+                name: displayName,
+                version: version,
+                applicationType: type
+            )
+            apps.append(app)
+        }
+
+        return apps.sorted { lhs, rhs in
+            lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
+        }
+    }
+
     /// Starts a simulator device
     /// - Parameter identifier: The device name or UUID to start
     /// - Throws: SimulatorError if the operation fails
@@ -916,6 +959,25 @@ class SimulatorService {
 
 // MARK: - Supporting Types for JSON Parsing
 
+private struct SimctlAppData: Decodable {
+    let bundleIdentifier: String?
+    let displayName: String?
+    let bundleName: String?
+    let applicationType: String?
+    let shortVersion: String?
+    let version: String?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: AnyCodingKey.self)
+        bundleIdentifier = container.decodeString(for: ["CFBundleIdentifier", "bundleIdentifier"])
+        displayName = container.decodeString(for: ["CFBundleDisplayName", "displayName"])
+        bundleName = container.decodeString(for: ["CFBundleName", "bundleName"])
+        applicationType = container.decodeString(for: ["ApplicationType", "applicationType"])
+        shortVersion = container.decodeString(for: ["CFBundleShortVersionString", "shortVersion"])
+        version = container.decodeString(for: ["CFBundleVersion", "version"])
+    }
+}
+
 private struct SimctlDeviceListResponse: Codable {
     let devices: [String: [SimctlDeviceData]]
 }
@@ -946,4 +1008,43 @@ private struct SimctlRuntimeData: Codable {
     let name: String
     let version: String
     let isAvailable: Bool?
+}
+
+private struct AnyCodingKey: CodingKey {
+    let stringValue: String
+    let intValue: Int?
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+        self.intValue = nil
+    }
+
+    init?(intValue: Int) {
+        self.stringValue = "\(intValue)"
+        self.intValue = intValue
+    }
+
+    init(_ string: String) {
+        self.stringValue = string
+        self.intValue = nil
+    }
+}
+
+private extension KeyedDecodingContainer where Key == AnyCodingKey {
+    func decodeString(for keys: [String]) -> String? {
+        for key in keys {
+            guard let codingKey = AnyCodingKey(stringValue: key) else { continue }
+            if let value = try decodeIfPresent(String.self, forKey: codingKey) {
+                return value
+            }
+        }
+        return nil
+    }
+}
+
+private extension Optional where Wrapped == String {
+    var trimmedNonEmpty: String? {
+        guard let value = self?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else { return nil }
+        return value
+    }
 }


### PR DESCRIPTION
## Summary
- add a `--apps` flag to `xsim list` to display user-installed apps beneath each simulator entry
- extend `SimulatorService` with listapps parsing and introduce a `SimulatorApp` model to filter out default apps
- document the new flag in the README for quick reference

## Testing
- `swift build` *(fails: unable to fetch SwiftCLI/Rainbow due to network restrictions in container)*
- `make format` *(fails: `swiftformat` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e38b91fb348331b7ff4a99866c0961